### PR TITLE
[CRM] Add the possibility to log your own mail to an opportunity

### DIFF
--- a/outlook/README.md
+++ b/outlook/README.md
@@ -6,3 +6,20 @@
 - `npm install`
 - `npm run-script build  -- --env.DOMAIN=127.0.0.1:8080` (replace `127.0.0.1:8080` with the actual domain)
 - serve the dist folder
+
+## To add the add-in in outlook for the web
+
+- Open any email
+- Click the three dot in the upper right corner of the mail
+- Click "Get add-ins"
+- Select "My add-ins"
+- Click the link "Add a custom add-in"
+- Select "Add from URL"
+- Paste the URL to the manifest.xml. E.g. https://download.odoo.com/plugins/outlook/manifest.xml
+
+## To pin the add-in
+
+- Click the cog in the upper right corner of the pain window
+- Select "View all Outlook settings"
+- Click "Mail" > "Customize actions"
+- Under the section "Message surface", check "Odoo for Outlook".

--- a/outlook/manifest.xml
+++ b/outlook/manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <OfficeApp xmlns="http://schemas.microsoft.com/office/appforoffice/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bt="http://schemas.microsoft.com/office/officeappbasictypes/1.0" xmlns:mailappor="http://schemas.microsoft.com/office/mailappversionoverrides/1.0" xsi:type="MailApp">
   <Id>c5549a21-aefb-4ba8-ae7c-b77bceab4023</Id>
-  <Version>1.0.2</Version>
+  <Version>1.1.0</Version>
   <ProviderName>Odoo</ProviderName>
   <DefaultLocale>en-US</DefaultLocale>
   <DisplayName DefaultValue="Odoo for Outlook"/>

--- a/outlook/manifest.xml
+++ b/outlook/manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <OfficeApp xmlns="http://schemas.microsoft.com/office/appforoffice/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bt="http://schemas.microsoft.com/office/officeappbasictypes/1.0" xmlns:mailappor="http://schemas.microsoft.com/office/mailappversionoverrides/1.0" xsi:type="MailApp">
   <Id>c5549a21-aefb-4ba8-ae7c-b77bceab4023</Id>
-  <Version>1.1.0</Version>
+  <Version>1.1.1</Version>
   <ProviderName>Odoo</ProviderName>
   <DefaultLocale>en-US</DefaultLocale>
   <DisplayName DefaultValue="Odoo for Outlook"/>

--- a/outlook/src/classes/EnrichmentInfo.ts
+++ b/outlook/src/classes/EnrichmentInfo.ts
@@ -15,13 +15,11 @@ class EnrichmentInfo {
 
     constructor(type?:EnrichmentInfoType, info?:string) {
         this.type = type || EnrichmentInfoType.None;
-        // Override the info returned by the service, unless we don't actually have a typical message.
-        // Messages' content should come from only one place, and ideally the front end.
-        this.info = this.getTypicalMessage(this.type) || info;
+        this.info = info;
     }
 
-    public getTypicalMessage(type: EnrichmentInfoType) {
-        switch (type) {
+    getTypicalMessage = () => {
+        switch (this.type) {
             case EnrichmentInfoType.None:
                 return "";
             case EnrichmentInfoType.CompanyCreated:

--- a/outlook/src/taskpane/components/Leads/Leads.tsx
+++ b/outlook/src/taskpane/components/Leads/Leads.tsx
@@ -57,7 +57,8 @@ class Leads extends React.Component<LeadsProps, LeadsState> {
         Office.context.mailbox.item.body.getAsync(Office.CoercionType.Html, (result) => {
         const msgHeader = '<div>From: '+ Office.context.mailbox.item.sender.emailAddress + '</div><br/>';
         const msgFooter = '<br/><div class="text-muted font-italic">Logged from <a href="https://www.odoo.com/documentation/user/crm/optimize/mail_client_extension.html" target="_blank">Outlook Inbox</a></div>';
-        const message = msgHeader + result.value + msgFooter;
+        const body = result.value.split('<div id="x_appendonsend"></div>')[0]; // Remove the history and only log the most recent message.
+        const message = msgHeader + body + msgFooter;
         const requestJson = {
             lead: leadId,
             message: message

--- a/outlook/src/taskpane/components/Main/Main.tsx
+++ b/outlook/src/taskpane/components/Main/Main.tsx
@@ -53,13 +53,21 @@ class Main extends React.Component<MainProps, MainState> {
         this.loadOrReload();
     }
 
+
     _connectedFlow = () => {
         if (!Office.context.mailbox.item) {
             return;
         }
-        
-        const email = Office.context.mailbox.item.from.emailAddress;
-        const displayName = Office.context.mailbox.item.from.displayName;
+
+        // If outlook is showing the oultook user's answer, we pick the sender of the original email.
+        // Which is most likely the first "to" address, until proven otherwise.
+        let email = Office.context.mailbox.item.from.emailAddress;
+        let displayName = Office.context.mailbox.item.from.displayName;
+        if (Office.context.mailbox.userProfile.emailAddress == Office.context.mailbox.item.from.emailAddress) {
+            email = Office.context.mailbox.item.to[0].emailAddress;
+            displayName = Office.context.mailbox.item.to[0].displayName;
+        }
+
         this.context.setIsLoading(true);
 
         const cancellablePartnerRequest = sendHttpRequest(HttpVerb.POST, api.baseURL + api.getPartner, ContentType.Json, this.context.getConnectionToken(), {
@@ -110,8 +118,16 @@ class Main extends React.Component<MainProps, MainState> {
   _disconnectedFlow() {
     Office.context.mailbox.getUserIdentityTokenAsync(idTokenResult=>{
         const userEmail = Office.context.mailbox.userProfile.emailAddress;
-        const senderEmail = Office.context.mailbox.item.from.emailAddress;
-        const senderDisplayName = Office.context.mailbox.item.from.displayName;
+
+        // The "sender" is the sender of the original mail.
+        // If outlook is showing the oultook user's answer, we pick the sender of the original email.
+        // Which is most likely the first "to" address, until proven otherwise.
+        let senderEmail = Office.context.mailbox.item.from.emailAddress;
+        let senderDisplayName = Office.context.mailbox.item.from.displayName;
+        if (Office.context.mailbox.userProfile.emailAddress == Office.context.mailbox.item.from.emailAddress) {
+            senderEmail = Office.context.mailbox.item.to[0].emailAddress;
+            senderDisplayName = Office.context.mailbox.item.to[0].displayName;
+        }
         const senderDomain = senderEmail.split('@')[1];
 
         const partner = new PartnerData();

--- a/outlook/src/taskpane/components/Main/Main.tsx
+++ b/outlook/src/taskpane/components/Main/Main.tsx
@@ -201,6 +201,7 @@ class Main extends React.Component<MainProps, MainState> {
 
     _getMessageBars = () => {
         const {type, info} = this.state.EnrichmentInfo;
+        const message = this.state.EnrichmentInfo.getTypicalMessage();
         let bars = [];
         if (this.state.showPartnerCreatedMessage && this.state.partnerCreated) {
             bars.push(<MessageBar messageBarType={MessageBarType.success} onDismiss={this._hidePartnerCreatedMessage}>Contact created</MessageBar>);
@@ -214,11 +215,12 @@ class Main extends React.Component<MainProps, MainState> {
                 break;
             case EnrichmentInfoType.NoData:
             case EnrichmentInfoType.NotConnected_NoData:
-                bars.push(<MessageBar messageBarType={MessageBarType.info} onDismiss={this._hideEnrichmentInfoMessage}>{info}</MessageBar>);
+                bars.push(<MessageBar messageBarType={MessageBarType.info} onDismiss={this._hideEnrichmentInfoMessage}>{message}</MessageBar>);
                 break;
             case EnrichmentInfoType.InsufficientCredit:
                 bars.push(<MessageBar messageBarType={MessageBarType.error} onDismiss={this._hideEnrichmentInfoMessage}>
-                    Could not auto-complete the company: not enough credits!
+                    {message}
+                    <br/>
                     <Link href={info} target="_blank">
                         Buy More
                     </Link>
@@ -228,7 +230,7 @@ class Main extends React.Component<MainProps, MainState> {
             case EnrichmentInfoType.NotConnected_InternalError:
             case EnrichmentInfoType.Other:
             case EnrichmentInfoType.ConnectionError:
-                bars.push(<MessageBar messageBarType={MessageBarType.error} onDismiss={this._hideEnrichmentInfoMessage}>{info}</MessageBar>);
+                bars.push(<MessageBar messageBarType={MessageBarType.error} onDismiss={this._hideEnrichmentInfoMessage}>{message}</MessageBar>);
                 break;
             }
         }


### PR DESCRIPTION
When outlook is displaying one of your own answers, the extension
- shows your client's details instead of your own
- allows logging the content of your own answer to the opportunities
of the client

This PR also fixes a bug where the `Buy more` (credits) link would 
redirect to a wrong URL.

Task ID: 2376540