### PR TITLE
[IMP] outlook: add translation support

### DIFF
--- a/outlook/src/classes/EnrichmentInfo.ts
+++ b/outlook/src/classes/EnrichmentInfo.ts
@@ -1,3 +1,5 @@
+import { _t } from "../utils/Translator";
+
 export enum EnrichmentInfoType {
     None = 'none',
     CompanyCreated = 'company_created',
@@ -8,7 +10,8 @@ export enum EnrichmentInfoType {
     EnrichContactWithNoEmail='enrich_contact_with_no_email',
     NotConnected_NoData = 'missing_data',
     NotConnected_InsufficientCredit = 'exhausted_requests',
-    NotConnected_InternalError = 'internal_error'
+    NotConnected_InternalError = 'internal_error',
+    CouldNotGetTranslations = 'could_not_get_translations'
 }
 class EnrichmentInfo {
     type: EnrichmentInfoType;
@@ -26,22 +29,25 @@ class EnrichmentInfo {
             case EnrichmentInfoType.None:
                 return "";
             case EnrichmentInfoType.CompanyCreated:
-                return "Company created!"
+                return _t("Company created");
             case EnrichmentInfoType.NoData:
             case EnrichmentInfoType.NotConnected_NoData:
-                return "No data found for this email address.";
+                return _t("No data found for this email address.");
             case EnrichmentInfoType.InsufficientCredit:
-                return "You don't have enough credit to enrich.";
+                return _t("You don't have enough credit to enrich.");
             case EnrichmentInfoType.NotConnected_InsufficientCredit:
+                //no need to translate since it appears only when the user is not logged in
                 return "Oops, looks like you have exhausted your free enrichment requests. Please log in to try again.";
             case EnrichmentInfoType.Other:
-                return "Something bad happened. Please, try again later."
+                return _t("Something bad happened. Please, try again later.");
             case EnrichmentInfoType.NotConnected_InternalError:
-                return "Could not autocomplete the company. Internal error. Try again later...";
+                return _t("Could not autocomplete the company. Internal error. Try again later...");
             case EnrichmentInfoType.ConnectionError:
-                return "There was a problem contacting the service, please try again later."
+                return _t("There was a problem contacting the service, please try again later.");
             case EnrichmentInfoType.EnrichContactWithNoEmail:
-                return "This contact has no email address, no company could be enriched."
+                return _t("This contact has no email address, no company could be enriched.");
+            case EnrichmentInfoType.CouldNotGetTranslations:
+                return _t("An error has occurred when trying to fetch translations.");
             default:
                 return "";
         }

--- a/outlook/src/taskpane/api.js
+++ b/outlook/src/taskpane/api.js
@@ -8,6 +8,7 @@ const api = {
     iapLeadEnrichment: "https://iap-services.odoo.com/iap/mail_extension/enrich",
     logSingleMail:"/mail_plugin/log_mail_content",
     searchPartner: "/mail_plugin/partner/search",
+    getTranslations: "/mail_plugin/get_translations",
 
     // Authentication
     loginPage: "/web/login", // Should be the usual Odoo login page.

--- a/outlook/src/taskpane/components/App.tsx
+++ b/outlook/src/taskpane/components/App.tsx
@@ -5,6 +5,7 @@ import AppContext from './AppContext';
 import EnrichmentInfo, {EnrichmentInfoType} from "../../classes/EnrichmentInfo";
 import {IIconProps, Link, MessageBar, MessageBarType} from "office-ui-fabric-react";
 import Progress from "./GrayOverlay";
+import { _t } from "../../utils/Translator";
 
 enum Page {
     Login,
@@ -51,7 +52,6 @@ export default class App extends React.Component<AppProps, AppState> {
             showEnrichmentInfoMessage: false,
             pageDisplayed: Page.Main,
             loginErrorMessage: "",
-            
             navigation: {
                 goToLogin: this.goToLogin,
                 goToMain: this.goToMain
@@ -61,6 +61,8 @@ export default class App extends React.Component<AppProps, AppState> {
             },
             disconnect: () => {
                 localStorage.removeItem('odooConnectionToken');
+                localStorage.removeItem('translations');
+                localStorage.removeItem('translationsTimestamp');
             },
             getConnectionToken: () => {
                 return 'Bearer ' + localStorage.getItem('odooConnectionToken');
@@ -121,12 +123,12 @@ export default class App extends React.Component<AppProps, AppState> {
         };
         let bars = [];
         if (this.state.showPartnerCreatedMessage) {
-            bars.push(<MessageBar messageBarType={MessageBarType.success} onDismiss={this.hidePartnerCreatedMessage}>Contact created</MessageBar>);
+            bars.push(<MessageBar messageBarType={MessageBarType.success} onDismiss={this.hidePartnerCreatedMessage}>{_t("Contact created")}</MessageBar>);
         }
         if (this.state.showEnrichmentInfoMessage) {
             switch (type) {
                 case EnrichmentInfoType.CompanyCreated:
-                    bars.push(<MessageBar messageBarType={MessageBarType.success} onDismiss={this.hideEnrichmentInfoMessage}>Company created</MessageBar>);
+                    bars.push(<MessageBar messageBarType={MessageBarType.success} onDismiss={this.hideEnrichmentInfoMessage}>{_t("Company created")}</MessageBar>);
                     break;
                 case EnrichmentInfoType.NoData:
                 case EnrichmentInfoType.NotConnected_NoData:
@@ -138,7 +140,7 @@ export default class App extends React.Component<AppProps, AppState> {
                         {message}
                         <br/>
                         <Link href={info} target="_blank">
-                            Buy More
+                            {_t("Buy More")}
                         </Link>
                     </MessageBar>);
                     break;
@@ -146,6 +148,7 @@ export default class App extends React.Component<AppProps, AppState> {
                 case EnrichmentInfoType.NotConnected_InsufficientCredit:
                 case EnrichmentInfoType.NotConnected_InternalError:
                 case EnrichmentInfoType.Other:
+                case EnrichmentInfoType.CouldNotGetTranslations:
                 case EnrichmentInfoType.ConnectionError:
                     bars.push(<MessageBar messageBarType={MessageBarType.error} messageBarIconProps={warningIcon} onDismiss={this.hideEnrichmentInfoMessage}>{message}</MessageBar>);
                     break;

--- a/outlook/src/taskpane/components/Company/CompanySection/CompanySection.tsx
+++ b/outlook/src/taskpane/components/Company/CompanySection/CompanySection.tsx
@@ -26,6 +26,7 @@ import CompanyCache from "../../../../classes/CompanyCache";
 import EnrichmentInfo, {EnrichmentInfoType} from "../../../../classes/EnrichmentInfo";
 import {Spinner, SpinnerSize} from "office-ui-fabric-react";
 import {OdooTheme} from "../../../../utils/Themes";
+import { _t } from "../../../../utils/Translator";
 
 type CompanySectionProps = {
     partner: Partner;
@@ -61,8 +62,8 @@ class CompanySection extends React.Component<CompanySectionProps, CompanySection
 
         if (!this.props.partner.email)
         {
-            let enrichmentInfo = new EnrichmentInfo(EnrichmentInfoType.EnrichContactWithNoEmail, "This contact has no email address," +
-                " no company could be enriched");
+            let enrichmentInfo = new EnrichmentInfo(EnrichmentInfoType.EnrichContactWithNoEmail,
+                _t("This contact has no email address, no company could be enriched."));
             this.context.showTopBarMessage(enrichmentInfo);
             return;
         }
@@ -116,10 +117,10 @@ class CompanySection extends React.Component<CompanySectionProps, CompanySection
                 enrichAndCreate = (
                     <div>
                         <div>
-                            No company attached to this contact
+                            {_t("No company attached to this contact")}
                         </div>
                         <div className="odoo-secondary-button" style={{margin: "8px auto auto auto"}} onClick={this.enrichCompanyForPartnerRequest}>
-                            Create a Company
+                            {_t("Create a Company")}
                         </div>
                     </div>
                 );
@@ -130,7 +131,7 @@ class CompanySection extends React.Component<CompanySectionProps, CompanySection
                 {
                     enrichAndCreate = (
                         <div>
-                            No company linked to this contact could be enriched
+                            {_t("No company linked to this contact could be enriched")}
                         </div>
                     );
                 }
@@ -138,7 +139,7 @@ class CompanySection extends React.Component<CompanySectionProps, CompanySection
                 {
                     enrichAndCreate = (
                         <div>
-                            No company linked to this contact could be enriched or found in Odoo
+                            {_t("No company linked to this contact could be enriched or found in Odoo")}
                         </div>
                     );
                 }
@@ -156,57 +157,57 @@ class CompanySection extends React.Component<CompanySectionProps, CompanySection
         if (company.getLocation())
         {
             addressSection = <CompanyInfoItem
-                icon={faMapMarkerAlt} title={"Address"} value={company.getLocation()}
+                icon={faMapMarkerAlt} title={_t("Address")} value={company.getLocation()}
                 hrefContent={`http://maps.google.com/?q=${company.getLocation()}`}/>
         }
         let phoneSection = null;
         if (company.getPhone())
         {
-            phoneSection = <CompanyInfoItem icon={faPhone} title={"Phone"} value={company.getPhone()}
+            phoneSection = <CompanyInfoItem icon={faPhone} title={_t("Phone")} value={company.getPhone()}
                                             hrefContent={`tel:${company.getPhone()}`}/>
         }
 
         let websiteSection = null;
         if (company.getDomain())
         {
-            websiteSection = <CompanyInfoItem icon={faGlobeEurope} title={"Website"} value={company.getDomain()}
+            websiteSection = <CompanyInfoItem icon={faGlobeEurope} title={_t("Website")} value={company.getDomain()}
                                               hrefContent={company.getDomain()}/>
         }
 
         let industrySection = null;
         if (company.getIndustry())
         {
-            industrySection = <CompanyInfoItem icon={faIndustry} title={"Industry"} value={company.getIndustry()}/>
+            industrySection = <CompanyInfoItem icon={faIndustry} title={_t("Industry")} value={company.getIndustry()}/>
         }
 
         let employeesSection = null;
         if (company.getEmployees())
         {
-            employeesSection = <CompanyInfoItem icon={faPersonBooth} title={"Employees"} value={company.getEmployees()+''}/>
+            employeesSection = <CompanyInfoItem icon={faPersonBooth} title={_t("Employees")} value={company.getEmployees()+''}/>
         }
 
         let yearFoundedSection = null;
         if (company.getYearFounded())
         {
-            yearFoundedSection = <CompanyInfoItem icon={faInfo} title={"Year founded"} value={company.getYearFounded()+""}/>
+            yearFoundedSection = <CompanyInfoItem icon={faInfo} title={_t("Year founded")} value={company.getYearFounded()+""}/>
         }
 
         let keywordsSection = null;
         if (company.getKeywords())
         {
-            keywordsSection = <CompanyInfoItem icon={faKey} title={"Keywords"} value={company.getKeywords()}/>
+            keywordsSection = <CompanyInfoItem icon={faKey} title={_t("Keywords")} value={company.getKeywords()}/>
         }
 
         let companyTypeSection = null;
         if (company.getCompanyType())
         {
-            companyTypeSection = <CompanyInfoItem icon={faBuilding} title={"Company Type"} value={company.getCompanyType()}/>
+            companyTypeSection = <CompanyInfoItem icon={faBuilding} title={_t("Company Type")} value={company.getCompanyType()}/>
         }
 
         let revenueSection = null;
         if (company.getRevenue())
         {
-            revenueSection = <CompanyInfoItem icon={faDollarSign} title={"Revenues"} value={company.getRevenue()}/>
+            revenueSection = <CompanyInfoItem icon={faDollarSign} title={_t("Revenues")} value={company.getRevenue()}/>
         }
 
         const profileCardData: ProfileCardProps = {
@@ -278,7 +279,7 @@ class CompanySection extends React.Component<CompanySectionProps, CompanySection
 
         return (
             <>
-                <CollapseSection title={"Company Insights"} isCollapsed={this.state.isCollapsed}
+                <CollapseSection title={_t("Company Insights")} isCollapsed={this.state.isCollapsed}
                                  onCollapseButtonClick={this.onCollapseClick} hideCollapseButton={this.props.hideCollapseButton}>
                     {content}
                 </CollapseSection>

--- a/outlook/src/taskpane/components/Contact/ContactList/ContactListItem/ContactListItem.tsx
+++ b/outlook/src/taskpane/components/Contact/ContactList/ContactListItem/ContactListItem.tsx
@@ -4,6 +4,7 @@ import AppContext from '../../../AppContext';
 import Partner from "../../../../../classes/Partner";
 import './ContactListItem.css';
 import Logger from "../../../Log/Logger";
+import { _t } from "../../../../../utils/Translator";
 
 type CustomContactListItemProps = {
     partner: Partner;
@@ -46,7 +47,7 @@ class ContactListItem extends React.Component<CustomContactListItemProps, {} > {
 
         if (this.props.partner.isAddedToDatabase())
         {
-            logButton = (<Logger resId={this.props.partner.id} model="res.partner" tooltipContent="Log Email Into Contact"/>);
+            logButton = (<Logger resId={this.props.partner.id} model="res.partner" tooltipContent={_t("Log Email Into Contact")}/>);
         }
 
         let classNames = "contact-list-item-container";

--- a/outlook/src/taskpane/components/Crm/LeadList/LeadListItem.tsx
+++ b/outlook/src/taskpane/components/Crm/LeadList/LeadListItem.tsx
@@ -5,6 +5,7 @@ import "../../Contact/ContactList/ContactListItem/ContactListItem.css";
 import api from "../../../api";
 import Logger from "../../Log/Logger";
 import "../../../../utils/ListItem.css"
+import { _t } from "../../../../utils/Translator";
 
 type LeadsListItemProps = {
     lead: Lead;
@@ -18,13 +19,19 @@ const LeadListItem = (props: LeadsListItemProps) => {
         window.open(url,"_blank");
     }
 
-    let expectedRevenueString = props.lead.expectedRevenue+" at "+props.lead.probability+"%";
+    let expectedRevenueString = _t("%(expected_revenue)s at %(probability)s%", {
+        expected_revenue: props.lead.expectedRevenue,
+        probability: props.lead.probability
+    });
 
     if (props.lead.recurringPlan)
     {
-        expectedRevenueString = props.lead.expectedRevenue+ " + "+props.lead.recurringRevenue
-            +" "+props.lead.recurringPlan
-            +" at "+props.lead.probability+"%";
+        expectedRevenueString = _t("%(expected_revenue)s + %(recurring_revenue)s %(recurring_plan)s at %(probability)s%", {
+            expected_revenue: props.lead.expectedRevenue,
+            recurring_revenue: props.lead.recurringRevenue,
+            recurring_plan: props.lead.recurringPlan,
+            probability: props.lead.probability
+        });
     }
 
     let expectedRevenuesText = (
@@ -42,7 +49,7 @@ const LeadListItem = (props: LeadsListItemProps) => {
                     </div>
                     {expectedRevenuesText}
                 </div>
-                <Logger resId={props.lead.id} model="crm.lead" tooltipContent="Log Email Into Lead"/>
+                <Logger resId={props.lead.id} model="crm.lead" tooltipContent={_t("Log Email Into Lead")}/>
             </div>
         </div>
     );

--- a/outlook/src/taskpane/components/Crm/LeadsSection/LeadsSection.tsx
+++ b/outlook/src/taskpane/components/Crm/LeadsSection/LeadsSection.tsx
@@ -8,6 +8,7 @@ import LeadListItem from "../LeadList/LeadListItem";
 import CollapseSection from "../../CollapseSection/CollapseSection";
 
 import {ContentType, HttpVerb, sendHttpRequest} from "../../../../utils/httpRequest";
+import { _t } from "../../../../utils/Translator";
 
 
 type LeadSectionProps = {
@@ -74,7 +75,7 @@ class LeadsSection extends React.Component<LeadSectionProps, LeadsSectionState> 
 
         let leadsExpanded = null;
 
-        let title = "Opportunities";
+        let title = _t("Opportunities");
 
         if (!this.props.partner.isAddedToDatabase())
         {
@@ -82,7 +83,7 @@ class LeadsSection extends React.Component<LeadSectionProps, LeadsSectionState> 
             {
                 leadsExpanded = (
                   <div className="list-text">
-                      Save Contact to create new Opportunities.
+                      {_t("Save Contact to create new Opportunities.")}
                   </div>
                 );
             }
@@ -110,7 +111,7 @@ class LeadsSection extends React.Component<LeadSectionProps, LeadsSectionState> 
                 {
                     leadsContent = (
                         <div className="list-text">
-                            No opportunities found for this contact
+                            {_t("No opportunities found for this contact.")}
                         </div>
                     );
                 }
@@ -124,7 +125,7 @@ class LeadsSection extends React.Component<LeadSectionProps, LeadsSectionState> 
 
 
         if (this.state.leads)
-            title = `Opportunities (${this.state.leads.length})`;
+            title = _t("Opportunities (%(count)s)", {count: this.props.partner.leads.length.toString()});
 
         return (
             <>

--- a/outlook/src/taskpane/components/Helpdesk/TicketList/TicketListItem.tsx
+++ b/outlook/src/taskpane/components/Helpdesk/TicketList/TicketListItem.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import HelpdeskTicket from "../../../../classes/HelpdeskTicket";
 import '../../../../utils/ListItem.css'
+import { _t } from "../../../../utils/Translator";
 import api from "../../../api";
 import Logger from "../../Log/Logger";
 
@@ -20,7 +21,7 @@ const TicketListItem = (props: TicketListItemProps) => {
 
     if (props.ticket.isClosed)
     {
-        closedText = (<div className="muted-text" style={{marginTop: "8px", fontSize: "14px"}}>Closed</div>)
+        closedText = (<div className="muted-text" style={{marginTop: "8px", fontSize: "14px"}}>{_t("Closed")}</div>)
     }
 
     return (
@@ -32,7 +33,7 @@ const TicketListItem = (props: TicketListItemProps) => {
                     </div>
                     {closedText}
                 </div>
-                <Logger resId={props.ticket.id} model="helpdesk.ticket" tooltipContent="Log Email Into Ticket"/>
+                <Logger resId={props.ticket.id} model="helpdesk.ticket" tooltipContent={_t("Log Email Into Ticket")}/>
             </div>
         </div>
     );

--- a/outlook/src/taskpane/components/Helpdesk/TicketsSection/TicketsSection.tsx
+++ b/outlook/src/taskpane/components/Helpdesk/TicketsSection/TicketsSection.tsx
@@ -7,6 +7,7 @@ import AppContext from '../../AppContext';
 import "../../../../utils/ListItem.css";
 import TicketListItem from "../TicketList/TicketListItem";
 import {ContentType, HttpVerb, sendHttpRequest} from "../../../../utils/httpRequest";
+import { _t } from "../../../../utils/Translator";
 
 type TicketsSectionProps = {
     partner: Partner;
@@ -73,7 +74,7 @@ class TicketsSection extends React.Component<TicketsSectionProps, TicketsSection
 
         let ticketsExpanded = null;
 
-        let title = "Tickets";
+        let title = _t("Tickets");
 
         if (!this.props.partner.isAddedToDatabase())
         {
@@ -81,7 +82,7 @@ class TicketsSection extends React.Component<TicketsSectionProps, TicketsSection
             {
                 ticketsExpanded = (
                     <div className="list-text">
-                        Save Contact to create new Tickets.
+                        {_t("Save Contact to create new Tickets.")}
                     </div>
                 );
             }
@@ -112,7 +113,7 @@ class TicketsSection extends React.Component<TicketsSectionProps, TicketsSection
                 {
                     leadsContent = (
                         <div className="list-text">
-                            No tickets found for this contact
+                            {_t("No tickets found for this contact.")}
                         </div>
                     );
                 }
@@ -126,7 +127,7 @@ class TicketsSection extends React.Component<TicketsSectionProps, TicketsSection
 
 
         if (this.state.tickets)
-            title = `Tickets (${this.state.tickets.length})`;
+            title = _t("Tickets (%(count)s)", {count: this.state.tickets.length});
 
         return (
             <>

--- a/outlook/src/taskpane/components/Search/Search.tsx
+++ b/outlook/src/taskpane/components/Search/Search.tsx
@@ -10,6 +10,7 @@ import {OdooTheme} from "../../../utils/Themes";
 import {faSearch} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {TextField} from "office-ui-fabric-react/lib-amd";
+import { _t } from "../../../utils/Translator";
 
 const MAX_PARTNERS = 30;
 
@@ -119,7 +120,7 @@ class Search extends React.Component<SearchProps, SearchState> {
 
         let searchBar = (
             <div style={{display: "flex", flexDirection: "row", alignItems: "center", justifyContent: "stretch", margin: "8px 8px 16px 8px"}}>
-                <TextField className="input-search" placeholder='Search contact in Odoo...'
+                <TextField className="input-search" placeholder={_t('Search contact in Odoo...')}
                        onChange={this.onQueryChanged} value={this.state.query} onKeyDown={this.onKeyDown}
                        onFocus={(e) => e.target.select()}
                 />
@@ -147,7 +148,9 @@ class Search extends React.Component<SearchProps, SearchState> {
                     <div className="section-top">
                         <div className="custom-section-title-container">
                             <div className="section-title-text custom">
-                                Contacts Found ({foundContactsNumberText})
+                                {_t("Contacts Found (%(count)s)", {
+                                    count: foundContactsNumberText
+                                })}
                             </div>
                         </div>
                     </div>

--- a/outlook/src/utils/Translator.ts
+++ b/outlook/src/utils/Translator.ts
@@ -1,0 +1,78 @@
+//Threshold in miliseconds after which translations are considered as expired
+const EXPIRATION_TRESHOLD = 24 * 60 * 60 * 1000; //set to 24 hours
+
+function getTranslations(): String[] {
+    try {
+        return JSON.parse(localStorage.getItem("translations"));
+    }
+    catch (e) {
+        return null;
+    }
+}
+
+/**
+ * Returns true if there are no translations or if translations have expired)
+ */
+export function translationsExpired(): boolean {
+    if (getTranslations() == null)
+    {
+        return true;
+    }
+    const translationsDate = new Date(Number(localStorage.getItem("translationsTimestamp")));
+    //check if translations have expired (are older then the threshold)
+    return (((Date.now() - translationsDate.getTime())) >= EXPIRATION_TRESHOLD);
+}
+
+/**
+ * saves translations in local storage
+ * @param translations translations to save
+ */
+export function saveTranslations(translations: String[]): void {
+    localStorage.setItem("translations", JSON.stringify(translations));
+    localStorage.setItem("translationsTimestamp", JSON.stringify(Date.now()));
+}
+
+/**
+ * returns a string where each %(param)s is replaced by it's corresponding param
+ * @param s input string which can contain some
+ * @param params corresponding values for each "%(param)s" found in the string
+ */
+
+function subReplace(s: string, params?: any): string
+{
+    if (params)
+    {
+        let replaced = s.replace(/%\((.+?)\)s/g, (g1, g2) => {
+            if (params[g2] != undefined)
+            {
+                return params[g2];
+            }
+            else
+            {
+                return g1;
+            }
+        });
+        return replaced;
+    }
+    else
+    {
+        return s;
+    }
+}
+
+/**
+ * returns a string's corresponding translation, if no translation is found, fallsback to the input string itself
+ * @param s the string to translate
+ * @param params corresponding value for each "%(param)s" found in the string.
+ */
+export function _t(s: string, params?: any): string {
+    const translations = getTranslations() as string[];
+    if (translations && translations[s])
+    {
+        return subReplace(translations[s], params);
+    }
+    else
+    {
+        return subReplace(s, params);
+    }
+};


### PR DESCRIPTION
Add translation support for the outlook mail plugin, using Odoo translations.

The translations are fetched from the odoo server and then stored in the user's
local storage, and updated after a certain duration.

This will allow having translations handled by Odoo, which has several
advantages:
- existing system, nothing to develop
- it will use transifex and the terms will be translated by the community
- forces that mail_client implementations to have the same logic (consistency)

Task-2480075

COM-PR: https://github.com/odoo/odoo/pull/69118
ENT-PR: https://github.com/odoo/enterprise/pull/17626