### PR TITLE
[FIX] outlook: fix multi_company access error

### DIFF
--- a/outlook/src/taskpane/components/App.tsx
+++ b/outlook/src/taskpane/components/App.tsx
@@ -23,6 +23,7 @@ export interface AppState {
     EnrichmentInfo: EnrichmentInfo;
     showPartnerCreatedMessage: boolean;
     showEnrichmentInfoMessage: boolean;
+    userCompanies: number[];
     loginErrorMessage: string;
     navigation: {
         goToLogin: () => void,
@@ -31,9 +32,11 @@ export interface AppState {
     connect: (token) => void,
     disconnect: () => void,
     getConnectionToken: () => void,
+    getUserCompaniesString: () => string,
     isConnected: () => Boolean,
     cancelRequests: () => void,
     addRequestCanceller: (canceller: () => void) => void,
+    setUserCompanies: (userCompanies: number[]) => void,
     showTopBarMessage: (enrichmentInfo?: EnrichmentInfo) => void,
     showHttpErrorMessage: (error) => void
 }
@@ -50,6 +53,7 @@ export default class App extends React.Component<AppProps, AppState> {
             EnrichmentInfo: new EnrichmentInfo(),
             showPartnerCreatedMessage: false,
             showEnrichmentInfoMessage: false,
+            userCompanies: [],
             pageDisplayed: Page.Main,
             loginErrorMessage: "",
             navigation: {
@@ -67,6 +71,13 @@ export default class App extends React.Component<AppProps, AppState> {
             getConnectionToken: () => {
                 return 'Bearer ' + localStorage.getItem('odooConnectionToken');
             },
+            getUserCompaniesString: () => {
+                if (this.state.userCompanies.length == 0) {
+                    return '';
+                } else {
+                    return `&cids=${this.state.userCompanies.sort().join(',')}`;
+                }
+            },
             isConnected: () => {
                 return !!localStorage.getItem('odooConnectionToken');
             },
@@ -79,6 +90,10 @@ export default class App extends React.Component<AppProps, AppState> {
             },
             addRequestCanceller: (canceller: () => void) => {
                 this.requestCancellers.push(canceller);
+            },
+
+            setUserCompanies: (companies: number[]) => {
+                this.setState({userCompanies: companies});
             },
 
             showTopBarMessage: (enrichmentInfo) => {

--- a/outlook/src/taskpane/components/Contact/ContactPage/ContactPage.tsx
+++ b/outlook/src/taskpane/components/Contact/ContactPage/ContactPage.tsx
@@ -58,6 +58,9 @@ class ContactPage extends React.Component<ContactPageProps, ContactPageState> {
             {
                 partner.tickets = parsed.result.tickets.map(ticket_json => HelpdeskTicket.fromJSON(ticket_json));
             }
+            if (parsed.result.user_companies) {
+                this.context.setUserCompanies(parsed.result.user_companies);
+            }
             this.setState({partner: partner, isLoading: false});
             if (parsed.result.partner['enrichment_info'])
             {

--- a/outlook/src/taskpane/components/Contact/ContactSection/ContactSection.tsx
+++ b/outlook/src/taskpane/components/Contact/ContactSection/ContactSection.tsx
@@ -4,7 +4,7 @@ import Partner from "../../../../classes/Partner";
 import ContactListItem from "../ContactList/ContactListItem/ContactListItem";
 
 import api from "../../../api";
-
+import AppContext from '../../AppContext';
 
 type ContactSectionProps = {
     partner: Partner;
@@ -12,23 +12,27 @@ type ContactSectionProps = {
 };
 
 
-const ContactSection = (props: ContactSectionProps) => {
+class ContactSection extends React.Component<ContactSectionProps, {}> {
 
-    const viewContact = (partner) => {
-        let url = api.baseURL+`/web#id=${partner.id}&model=res.partner&view_type=form`;
+    viewContact = (partner) => {
+        const cids = this.context.getUserCompaniesString();
+        let url = api.baseURL+`/web#id=${partner.id}&model=res.partner&view_type=form${cids}`;
         window.open(url,"_blank");
     }
 
-    let selectable = props.partner.isAddedToDatabase();
-    let onItemClick = props.partner.isAddedToDatabase() ? viewContact : undefined;
+    render() {
+        let selectable = this.props.partner.isAddedToDatabase();
+        let onItemClick = this.props.partner.isAddedToDatabase() ? this.viewContact : undefined;
 
-    return (
-        <div className='section-card'>
-            <ContactListItem partner={props.partner} selectable={selectable}
-                             onItemClick={onItemClick}/>
-        </div>
-    )
+        return (
+            <div className='section-card'>
+                <ContactListItem partner={this.props.partner} selectable={selectable}
+                                 onItemClick={onItemClick}/>
+            </div>
+        );
+    }
 
 }
+ContactSection.contextType = AppContext;
 
 export default ContactSection;

--- a/outlook/src/taskpane/components/Crm/LeadList/LeadListItem.tsx
+++ b/outlook/src/taskpane/components/Crm/LeadList/LeadListItem.tsx
@@ -6,54 +6,59 @@ import api from "../../../api";
 import Logger from "../../Log/Logger";
 import "../../../../utils/ListItem.css"
 import { _t } from "../../../../utils/Translator";
+import AppContext from '../../AppContext';
 
 type LeadsListItemProps = {
     lead: Lead;
 };
 
 
-const LeadListItem = (props: LeadsListItemProps) => {
+class LeadListItem extends React.Component<LeadsListItemProps, {}> {
 
-    const openInOdoo = () => {
-        let url = api.baseURL+`/web#id=${props.lead.id}&model=crm.lead&view_type=form`;
+    openInOdoo = () => {
+        const cids = this.context.getUserCompaniesString();
+        let url = api.baseURL+`/web#id=${this.props.lead.id}&model=crm.lead&view_type=form${cids}`;
         window.open(url,"_blank");
     }
 
-    let expectedRevenueString = _t("%(expected_revenue)s at %(probability)s%", {
-        expected_revenue: props.lead.expectedRevenue,
-        probability: props.lead.probability
-    });
-
-    if (props.lead.recurringPlan)
-    {
-        expectedRevenueString = _t("%(expected_revenue)s + %(recurring_revenue)s %(recurring_plan)s at %(probability)s%", {
-            expected_revenue: props.lead.expectedRevenue,
-            recurring_revenue: props.lead.recurringRevenue,
-            recurring_plan: props.lead.recurringPlan,
-            probability: props.lead.probability
+    render() {
+        let expectedRevenueString = _t("%(expected_revenue)s at %(probability)s%", {
+            expected_revenue: this.props.lead.expectedRevenue,
+            probability: this.props.lead.probability
         });
+
+        if (this.props.lead.recurringPlan) {
+            expectedRevenueString = _t("%(expected_revenue)s + %(recurring_revenue)s %(recurring_plan)s at %(probability)s%", {
+                expected_revenue: this.props.lead.expectedRevenue,
+                recurring_revenue: this.props.lead.recurringRevenue,
+                recurring_plan: this.props.lead.recurringPlan,
+                probability: this.props.lead.probability
+            });
+        }
+
+        let expectedRevenuesText = (
+            <div className="lead-list-item-revenue-text">
+                {expectedRevenueString}
+            </div>
+        );
+
+        return (
+            <div className="list-item-root-container" onClick={this.openInOdoo}>
+                <div className="list-item-container">
+                    <div className="list-item-info-container">
+                        <div className="list-item-title-text">
+                            {this.props.lead.name}
+                        </div>
+                        {expectedRevenuesText}
+                    </div>
+                    <Logger resId={this.props.lead.id} model="crm.lead" tooltipContent={_t("Log Email Into Lead")}/>
+                </div>
+            </div>
+        );
     }
 
-    let expectedRevenuesText = (
-        <div className="lead-list-item-revenue-text">
-            {expectedRevenueString}
-        </div>
-    );
-
-    return (
-        <div className="list-item-root-container" onClick={openInOdoo}>
-            <div className="list-item-container">
-                <div className="list-item-info-container">
-                    <div className="list-item-title-text">
-                        {props.lead.name}
-                    </div>
-                    {expectedRevenuesText}
-                </div>
-                <Logger resId={props.lead.id} model="crm.lead" tooltipContent={_t("Log Email Into Lead")}/>
-            </div>
-        </div>
-    );
-
 }
+
+LeadListItem.contextType = AppContext;
 
 export default LeadListItem;

--- a/outlook/src/taskpane/components/Crm/LeadsSection/LeadsSection.tsx
+++ b/outlook/src/taskpane/components/Crm/LeadsSection/LeadsSection.tsx
@@ -56,8 +56,9 @@ class LeadsSection extends React.Component<LeadSectionProps, LeadsSectionState> 
                 }
                 else
                 {
+                    const  cids = this.context.getUserCompaniesString();
                     const action = "crm_mail_plugin.crm_lead_action_form_edit";
-                    const url = api.baseURL + `/web#action=${action}&id=${parsed.result.lead_id}&model=crm.lead&view_type=form`;
+                    const url = api.baseURL + `/web#action=${action}&id=${parsed.result.lead_id}&model=crm.lead&view_type=form${cids}`;
                     window.open(url);
                 }
             }).catch(error => {

--- a/outlook/src/taskpane/components/Helpdesk/TicketList/TicketListItem.tsx
+++ b/outlook/src/taskpane/components/Helpdesk/TicketList/TicketListItem.tsx
@@ -3,6 +3,7 @@ import HelpdeskTicket from "../../../../classes/HelpdeskTicket";
 import '../../../../utils/ListItem.css'
 import { _t } from "../../../../utils/Translator";
 import api from "../../../api";
+import AppContext from "../../AppContext";
 import Logger from "../../Log/Logger";
 
 type TicketListItemProps = {
@@ -10,34 +11,39 @@ type TicketListItemProps = {
 };
 
 
-const TicketListItem = (props: TicketListItemProps) => {
+class TicketListItem extends React.Component<TicketListItemProps, {}>{
 
-    const openInOdoo = () => {
-        let url = api.baseURL+`/web#id=${props.ticket.id}&model=helpdesk.ticket&view_type=form`;
-        window.open(url,"_blank");
+    openInOdoo = () => {
+        const cids = this.context.getUserCompaniesString();
+        let url = api.baseURL + `/web#id=${this.props.ticket.id}&model=helpdesk.ticket&view_type=form${cids}`;
+        window.open(url, "_blank");
     }
 
-    let closedText = null;
+    render() {
+        let closedText = null;
 
-    if (props.ticket.isClosed)
-    {
-        closedText = (<div className="muted-text" style={{marginTop: "8px", fontSize: "14px"}}>{_t("Closed")}</div>)
-    }
+        if (this.props.ticket.isClosed) {
+            closedText = (<div className="muted-text" style={{marginTop: "8px", fontSize: "14px"}}>{_t("Closed")}</div>)
+        }
 
-    return (
-        <div className="list-item-root-container" onClick={openInOdoo}>
-            <div className="list-item-container">
-                <div className="list-item-info-container">
-                    <div className="list-item-title-text">
-                        {props.ticket.name}
+        return (
+            <div className="list-item-root-container" onClick={this.openInOdoo}>
+                <div className="list-item-container">
+                    <div className="list-item-info-container">
+                        <div className="list-item-title-text">
+                            {this.props.ticket.name}
+                        </div>
+                        {closedText}
                     </div>
-                    {closedText}
+                    <Logger resId={this.props.ticket.id} model="helpdesk.ticket"
+                            tooltipContent={_t("Log Email Into Ticket")}/>
                 </div>
-                <Logger resId={props.ticket.id} model="helpdesk.ticket" tooltipContent={_t("Log Email Into Ticket")}/>
             </div>
-        </div>
-    );
+        );
+    }
 
 }
+
+TicketListItem.contextType = AppContext;
 
 export default TicketListItem;

--- a/outlook/src/taskpane/components/Helpdesk/TicketsSection/TicketsSection.tsx
+++ b/outlook/src/taskpane/components/Helpdesk/TicketsSection/TicketsSection.tsx
@@ -33,8 +33,7 @@ class TicketsSection extends React.Component<TicketsSectionProps, TicketsSection
 
     private createTicketRequest = () => {
 
-        Office.context.mailbox.item.body.getAsync(Office.CoercionType.Html, (result) =>
-        {
+        Office.context.mailbox.item.body.getAsync(Office.CoercionType.Html, (result) => {
             const message = result.value.split('<div id="x_appendonsend"></div>')[0]; // Remove the history and only log the most recent message.
             const subject = Office.context.mailbox.item.subject;
 
@@ -49,14 +48,13 @@ class TicketsSection extends React.Component<TicketsSectionProps, TicketsSection
                 this.context.getConnectionToken(), requestJson, true);
             createTicketRequest.promise.then(response => {
                 const parsed = JSON.parse(response);
-                if (parsed['error']){
+                if (parsed['error']) {
                     this.context.showTopBarMessage();
                     return;
-                }
-                else
-                {
+                } else {
+                    const cids = this.context.getUserCompaniesString();
                     const action = "helpdesk_mail_plugin.helpdesk_ticket_action_form_edit";
-                    const url = api.baseURL + `/web#action=${action}&id=${parsed.result.ticket_id}&model=helpdesk.ticket&view_type=form`;
+                    const url = api.baseURL + `/web#action=${action}&id=${parsed.result.ticket_id}&model=helpdesk.ticket&view_type=form${cids}`;
                     window.open(url);
                 }
             }).catch(error => {


### PR DESCRIPTION
This commit fixes the multi_company access error when the user is attempting to
see a record belonging to another company then the one he is logged in to from
the plugins, based on the company_id of the record, the user will be redirected
to the record having the right company ticked.

Task-2541205

COM-PR: odoo/odoo#71318
ENT-PR: odoo/enterprise#18557