### PR TITLE
[IMP] gmail: allow to upload attachments when logging an email

### DIFF
--- a/gmail/src/global.d.ts
+++ b/gmail/src/global.d.ts
@@ -3,3 +3,4 @@ type Card = any;
 type ActionEvent = any;
 type CardSection = any;
 type Button = any;
+type GmailAttachment = any;

--- a/gmail/src/models/error_message.ts
+++ b/gmail/src/models/error_message.ts
@@ -14,6 +14,9 @@ const _ERROR_CODE_MESSAGES: Record<string, string> = {
         "Oops, looks like you have exhausted your free enrichment requests. Please log in to try again.",
     missing_data: "No data found for this email address.",
     unknown: "Something bad happened. Please, try again later.",
+    // Attachment
+    attachments_size_exceeded:
+        "Attachments could not be logged in Odoo because their total size exceeded the allowed maximum.",
 };
 
 /**

--- a/gmail/src/services/log_email.ts
+++ b/gmail/src/services/log_email.ts
@@ -1,18 +1,56 @@
 import { postJsonRpc } from "../utils/http";
+import { escapeHtml } from "../utils/html";
 import { URLS } from "../const";
+import { Email } from "../models/email";
 import { State } from "../models/state";
+import { ErrorMessage } from "../models/error_message";
+import { _t } from "../services/translation";
+
+/**
+ * Format the email body before sending it to Odoo.
+ * Add error message at the end of the email, fix some CSS issues,...
+ */
+function _formatEmailBody(email: Email, error: ErrorMessage): string {
+    let body = email.body;
+
+    body = `<span>${_t("From:")} ${escapeHtml(email.contactEmail)}</span><br/><br/>${body}`;
+
+    if (error.code === "attachments_size_exceeded") {
+        body += `<br/><i>${_t(
+            "Attachments could not be logged in Odoo because their total size exceeded the allowed maximum.",
+        )}</i>`;
+    }
+
+    // Make the "attachment" links bigger, otherwise we need to scroll to fully see them
+    // Can not add a <style/> tag because they are sanitized by Odoo
+    body = body.replace(
+        /class=\"gmail_chip gmail_drive_chip" style=\"/g,
+        'class="gmail_chip gmail_drive_chip" style=" min-height: 32px;',
+    );
+
+    body += `<br/><br/>${_t("Logged from")}<b> ${_t("Gmail Inbox")}</b>`;
+
+    return body;
+}
 
 /**
  * Log the given email body in the chatter of the given record.
  */
-export function logEmail(recordId: number, recordModel: string, emailBody: string): boolean {
-    const url = State.odooServerUrl + URLS.LOG_EMAIL;
+export function logEmail(recordId: number, recordModel: string, email: Email): ErrorMessage {
     const accessToken = State.accessToken;
+    const [attachments, error] = email.getAttachments();
+    const body = _formatEmailBody(email, error);
+    const url = State.odooServerUrl + URLS.LOG_EMAIL;
 
     const response = postJsonRpc(
         url,
-        { message: emailBody, res_id: recordId, model: recordModel },
+        { message: body, res_id: recordId, model: recordModel, attachments: attachments },
         { Authorization: "Bearer " + accessToken },
     );
-    return !!response;
+
+    if (!response) {
+        error.setError("http_error_odoo");
+    }
+
+    return error;
 }

--- a/gmail/src/services/translation.ts
+++ b/gmail/src/services/translation.ts
@@ -24,7 +24,7 @@ export class Translate {
 
             this.translations = postJsonRpc(
                 State.odooServerUrl + URLS.GET_TRANSLATIONS,
-                { },
+                {},
                 { Authorization: "Bearer " + State.accessToken },
             );
 

--- a/gmail/src/views/leads.ts
+++ b/gmail/src/views/leads.ts
@@ -8,11 +8,10 @@ import { Lead } from "../models/lead";
 import { State } from "../models/state";
 
 function onLogEmailOnLead(state: State, parameters: any) {
-    const emailBody = state.email.body;
     const leadId = parameters.leadId;
 
     if (State.setLoggingState(state.email.messageId, "leads", leadId)) {
-        logEmail(leadId, "crm.lead", emailBody);
+        state.error = logEmail(leadId, "crm.lead", state.email);
         return updateCard(buildView(state));
     }
     return notify(_t("Email already logged on the lead"));

--- a/gmail/src/views/partner.ts
+++ b/gmail/src/views/partner.ts
@@ -20,7 +20,6 @@ function onEnrichCompany(state: State) {
 }
 
 function onLogEmail(state: State) {
-    const emailBody = state.email.body;
     const partnerId = state.partner.id;
 
     if (!partnerId) {
@@ -28,7 +27,7 @@ function onLogEmail(state: State) {
     }
 
     if (State.setLoggingState(state.email.messageId, "partners", partnerId)) {
-        logEmail(partnerId, "res.partner", emailBody);
+        state.error = logEmail(partnerId, "res.partner", state.email);
         return updateCard(buildView(state));
     }
     return notify(_t("Email already logged on the contact"));

--- a/gmail/src/views/search_partner.ts
+++ b/gmail/src/views/search_partner.ts
@@ -17,7 +17,6 @@ function onSearchPartnerClick(state: State, parameters: any, inputs: any) {
     return updateCard(buildSearchPartnerView(state, query));
 }
 function onLogEmailPartner(state: State, parameters: any) {
-    const emailBody = state.email.body;
     const partnerId = parameters.partnerId;
 
     if (!partnerId) {
@@ -25,7 +24,7 @@ function onLogEmailPartner(state: State, parameters: any) {
     }
 
     if (State.setLoggingState(state.email.messageId, "partners", partnerId)) {
-        logEmail(partnerId, "res.partner", emailBody);
+        state.error = logEmail(partnerId, "res.partner", state.email);
         return updateCard(buildSearchPartnerView(state, parameters.query));
     }
     return notify(_t("Email already logged on the contact"));
@@ -92,7 +91,7 @@ export function buildSearchPartnerView(state: State, query: string, initialSearc
             );
 
         if (partner.email) {
-            partnerCard.setBottomLabel(partner.email)
+            partnerCard.setBottomLabel(partner.email);
         }
 
         searchSection.addWidget(partnerCard);

--- a/gmail/src/views/tickets.ts
+++ b/gmail/src/views/tickets.ts
@@ -23,11 +23,10 @@ function onCreateTicket(state: State) {
 }
 
 function onLogEmailOnTicket(state: State, parameters: any) {
-    const emailBody = state.email.body;
     const ticketId = parameters.ticketId;
 
     if (State.setLoggingState(state.email.messageId, "tickets", ticketId)) {
-        logEmail(ticketId, "helpdesk.ticket", emailBody);
+        state.error = logEmail(ticketId, "helpdesk.ticket", state.email);
         return updateCard(buildView(state));
     }
     return notify(_t("Email already logged on the ticket"));


### PR DESCRIPTION
Purpose
=======
Allow to upload the attachments when logging the email on the partner / lead / ticket.

Technical
=========
The attachments are base 64 encoded and then added in the JSON posted on the Odoo endpoint.

The maximum POST request size on the Gmail side is 50 MB. So when the attachments total size exceed 40 MB we just ignore them and show an error message.

N.B.: when creating an email from Gmail, if the sum of the file size is more than 25 MB, they are automatically uploaded on Drive and the links to those files are added in the email.

Links
=====
Task 2545048
See odoo/odoo/pull/71372