### PR TITLE
[FIX] gmail: set the user companies when redirecting to Odoo

### DIFF
--- a/gmail/src/main.ts
+++ b/gmail/src/main.ts
@@ -16,14 +16,17 @@ import { _t } from "../services/translation";
 function onGmailMessageOpen(event) {
     GmailApp.setCurrentMessageAccessToken(event.gmail.accessToken);
     const currentEmail = new Email(event.gmail.messageId);
-    const [partner, error] = Partner.enrichPartner(currentEmail.contactEmail, currentEmail.contactName);
+    const [partner, odooUserCompanies, error] = Partner.enrichPartner(
+        currentEmail.contactEmail,
+        currentEmail.contactName,
+    );
 
     if (!partner) {
         // Should at least use the FROM headers to generate the partner
         throw new Error(_t("Error during enrichment"));
     }
 
-    const state = new State(partner, currentEmail, null, null, error);
+    const state = new State(partner, currentEmail, odooUserCompanies, null, null, error);
 
     return [buildView(state)];
 }

--- a/gmail/src/models/state.ts
+++ b/gmail/src/models/state.ts
@@ -22,6 +22,8 @@ export class State {
     partner: Partner;
     // Opened email with headers
     email: Email;
+    // ID list of the Odoo user companies
+    odooUserCompanies: number[];
     // Searched partners in the search view
     searchedPartners: Partner[];
     // Searched projects in the search view
@@ -29,9 +31,17 @@ export class State {
     // Current error message displayed on the card
     error: ErrorMessage;
 
-    constructor(partner: Partner, email: Email, partners: Partner[], searchedProjects: Project[], error: ErrorMessage) {
+    constructor(
+        partner: Partner,
+        email: Email,
+        odooUserCompanies: number[],
+        partners: Partner[],
+        searchedProjects: Project[],
+        error: ErrorMessage,
+    ) {
         this.partner = partner;
         this.email = email;
+        this.odooUserCompanies = odooUserCompanies;
         this.searchedPartners = partners;
         this.searchedProjects = searchedProjects;
         this.error = error;
@@ -56,6 +66,7 @@ export class State {
         const partner = Partner.fromJson(partnerValues);
         const email = Email.fromJson(emailValues);
         const error = ErrorMessage.fromJson(errorValues);
+        const odooUserCompanies = values.odooUserCompanies;
         const searchedPartners = partnersValues
             ? partnersValues.map((partnerValues: any) => Partner.fromJson(partnerValues))
             : null;
@@ -63,7 +74,22 @@ export class State {
             ? projectsValues.map((projectValues: any) => Project.fromJson(projectValues))
             : null;
 
-        return new State(partner, email, searchedPartners, searchedProjects, error);
+        return new State(partner, email, odooUserCompanies, searchedPartners, searchedProjects, error);
+    }
+
+    /**
+     * Return the companies of the Odoo user as a GET parameter to add in a URL or an
+     * empty string if the information is missing.
+     *
+     * e.g.
+     *     &cids=1,3,7
+     */
+    get odooCompaniesParameter(): string {
+        if (this.odooUserCompanies && this.odooUserCompanies.length) {
+            const cids = this.odooUserCompanies.sort().join(",");
+            return `&cids=${cids}`;
+        }
+        return "";
     }
 
     /**

--- a/gmail/src/views/card_actions.ts
+++ b/gmail/src/views/card_actions.ts
@@ -10,8 +10,11 @@ function onLogout(state: State) {
     resetAccessToken();
     clearTranslationCache();
 
-    const [partner, error] = Partner.enrichPartner(state.email.contactEmail, state.email.contactName);
-    const newState = new State(partner, state.email, null, null, error);
+    const [partner, odooUserCompanies, error] = Partner.enrichPartner(
+        state.email.contactEmail,
+        state.email.contactName,
+    );
+    const newState = new State(partner, state.email, odooUserCompanies, null, null, error);
     return pushToRoot(buildView(newState));
 }
 

--- a/gmail/src/views/company.ts
+++ b/gmail/src/views/company.ts
@@ -10,6 +10,7 @@ import { _t } from "../services/translation";
 export function buildCompanyView(state: State, card: Card) {
     if (state.partner.company) {
         const odooServerUrl = State.odooServerUrl;
+        const cids = state.odooCompaniesParameter;
         const company = state.partner.company;
 
         const companySection = CardService.newCardSection().setHeader("<b>" + _t("Company") + "</b>");
@@ -25,7 +26,7 @@ export function buildCompanyView(state: State, card: Card) {
                 company.image || UI_ICONS.no_company,
                 null,
                 null,
-                company.id ? odooServerUrl + `/web#id=${company.id}&model=res.partner&view_type=form` : null,
+                company.id ? odooServerUrl + `/web#id=${company.id}&model=res.partner&view_type=form${cids}` : null,
                 false,
                 company.email,
                 CardService.ImageCropType.CIRCLE,

--- a/gmail/src/views/leads.ts
+++ b/gmail/src/views/leads.ts
@@ -27,10 +27,10 @@ function onCreateLead(state: State) {
     if (!leadId) {
         return notify(_t("Could not create the lead"));
     }
-
+    const cids = state.odooCompaniesParameter;
     const leadUrl =
         State.odooServerUrl +
-        `/web#id=${leadId}&action=crm_mail_plugin.crm_lead_action_form_edit&model=crm.lead&view_type=form`;
+        `/web#id=${leadId}&action=crm_mail_plugin.crm_lead_action_form_edit&model=crm.lead&view_type=form${cids}`;
 
     return openUrl(leadUrl);
 }
@@ -51,6 +51,7 @@ export function buildLeadsView(state: State, card: Card) {
     const leadsSection = CardService.newCardSection().setHeader(
         "<b>" + _t("Opportunities (%s)", leads.length) + "</b>",
     );
+    const cids = state.odooCompaniesParameter;
 
     if (state.partner.id) {
         leadsSection.addWidget(
@@ -100,7 +101,7 @@ export function buildLeadsView(state: State, card: Card) {
                     null,
                     leadRevenuesDescription,
                     leadButton,
-                    odooServerUrl + `/web#id=${lead.id}&model=crm.lead&view_type=form`,
+                    odooServerUrl + `/web#id=${lead.id}&model=crm.lead&view_type=form${cids}`,
                 ),
             );
         }

--- a/gmail/src/views/partner.ts
+++ b/gmail/src/views/partner.ts
@@ -93,6 +93,7 @@ export function buildPartnerView(state: State, card: Card) {
     const partnerContent = [partner.email, partner.phone]
         .filter((x) => x)
         .map((x) => `<font color="#777777">${x}</font>`);
+    const cids = state.odooCompaniesParameter;
 
     const partnerCard = createKeyValueWidget(
         null,
@@ -101,7 +102,7 @@ export function buildPartnerView(state: State, card: Card) {
         null,
         partnerButton,
         partner.id
-            ? odooServerUrl + `/web#id=${partner.id}&model=res.partner&view_type=form`
+            ? odooServerUrl + `/web#id=${partner.id}&model=res.partner&view_type=form${cids}`
             : canContactOdooDatabase
             ? null
             : actionCall(state, "buildLoginMainView"),

--- a/gmail/src/views/partner_actions.ts
+++ b/gmail/src/views/partner_actions.ts
@@ -17,7 +17,11 @@ function onSearchPartner(state: State) {
 }
 
 function onReloadPartner(state: State) {
-    [state.partner, state.error] = Partner.getPartner(state.partner.email, state.partner.name, state.partner.id);
+    [state.partner, state.odooUserCompanies, state.error] = Partner.getPartner(
+        state.partner.email,
+        state.partner.name,
+        state.partner.id,
+    );
 
     return updateCard(buildView(state));
 }

--- a/gmail/src/views/search_partner.ts
+++ b/gmail/src/views/search_partner.ts
@@ -32,8 +32,8 @@ function onLogEmailPartner(state: State, parameters: any) {
 
 function onOpenPartner(state: State, parameters: any) {
     const partner = parameters.partner;
-    const [newPartner, error] = Partner.getPartner(partner.email, partner.name, partner.id);
-    const newState = new State(newPartner, state.email, null, null, error);
+    const [newPartner, odooUserCompanies, error] = Partner.getPartner(partner.email, partner.name, partner.id);
+    const newState = new State(newPartner, state.email, odooUserCompanies, null, null, error);
     return pushCard(buildView(newState));
 }
 

--- a/gmail/src/views/tasks.ts
+++ b/gmail/src/views/tasks.ts
@@ -37,8 +37,8 @@ export function buildTasksView(state: State, card: Card) {
     }
 
     const loggingState = State.getLoggingState(state.email.messageId);
-
     const tasksSection = CardService.newCardSection().setHeader("<b>" + _t("Tasks (%s)", tasks.length) + "</b>");
+    const cids = state.odooCompaniesParameter;
 
     if (state.partner.id) {
         tasksSection.addWidget(
@@ -70,7 +70,7 @@ export function buildTasksView(state: State, card: Card) {
                     null,
                     null,
                     taskButton,
-                    odooServerUrl + `/web#id=${task.id}&model=project.task&view_type=form`,
+                    odooServerUrl + `/web#id=${task.id}&model=project.task&view_type=form${cids}`,
                 ),
             );
         }

--- a/gmail/src/views/tickets.ts
+++ b/gmail/src/views/tickets.ts
@@ -15,9 +15,11 @@ function onCreateTicket(state: State) {
         return notify("Could not create the ticket");
     }
 
+    const cids = state.odooCompaniesParameter;
+
     const ticketUrl =
         State.odooServerUrl +
-        `/web#id=${ticketId}&action=helpdesk_mail_plugin.helpdesk_ticket_action_form_edit&model=helpdesk.ticket&view_type=form`;
+        `/web#id=${ticketId}&action=helpdesk_mail_plugin.helpdesk_ticket_action_form_edit&model=helpdesk.ticket&view_type=form${cids}`;
 
     return openUrl(ticketUrl);
 }
@@ -54,6 +56,8 @@ export function buildTicketsView(state: State, card: Card) {
             CardService.newTextButton().setText(_t("Create")).setOnClickAction(actionCall(state, "onCreateTicket")),
         );
 
+        const cids = state.odooCompaniesParameter;
+
         for (let ticket of tickets) {
             let ticketButton = null;
             if (loggingState["tickets"].indexOf(ticket.id) >= 0) {
@@ -79,7 +83,7 @@ export function buildTicketsView(state: State, card: Card) {
                     null,
                     null,
                     ticketButton,
-                    odooServerUrl + `/web#id=${ticket.id}&model=helpdesk.ticket&view_type=form`,
+                    odooServerUrl + `/web#id=${ticket.id}&model=helpdesk.ticket&view_type=form${cids}`,
                 ),
             );
         }


### PR DESCRIPTION
Bug
===
In a multi-company environment, if the user click on a record (partner,
lead, task...) and if this record does not belong to the current
company, the user will have an access error.

To fix that, we return the companies of the current user and we add
them in the URL, so when the user is redirected to Odoo, all his
companies are selected and no access error occurs.

Task 2542179