### PR TITLE
[IMP] mail_plugin: enrich existing companies on the Gmail plugin

### DIFF
--- a/gmail/src/const.ts
+++ b/gmail/src/const.ts
@@ -5,7 +5,8 @@ const URLS: Record<string, string> = {
     GET_PARTNER: "/mail_plugin/partner/get",
     SEARCH_PARTNER: "/mail_plugin/partner/search",
     PARTNER_CREATE: "/mail_plugin/partner/create",
-    ENRICH_COMPANY: "/mail_plugin/partner/enrich_and_create_company",
+    CREATE_COMPANY: "/mail_plugin/partner/enrich_and_create_company",
+    ENRICH_COMPANY: "/mail_plugin/partner/enrich_and_update_company",
     // CRM Lead
     CREATE_LEAD: "/mail_plugin/lead/create",
     // HELPDESK Ticket

--- a/gmail/src/models/company.ts
+++ b/gmail/src/models/company.ts
@@ -5,6 +5,7 @@ export class Company {
     name: string;
     email: string;
     phone: string;
+    isEnriched: boolean;
 
     // Additional Information
     address: string;
@@ -40,6 +41,7 @@ export class Company {
         company.name = isTrue(values.name);
         company.email = first(values.email);
         company.phone = first(values.phone_numbers);
+        company.isEnriched = !!Object.keys(values).length;
 
         company.emails = isTrue(values.email) ? values.email.join("\n") : null;
         company.phones = isTrue(values.phone_numbers) ? values.phone_numbers.join("\n") : null;

--- a/gmail/src/models/error_message.ts
+++ b/gmail/src/models/error_message.ts
@@ -5,14 +5,16 @@ import { _t } from "../services/translation";
  */
 
 const _ERROR_CODE_MESSAGES: Record<string, string> = {
+    odoo: null, // Message is contained in the additional information
     http_error_odoo: "Could not connect to database. Try to log out and in.",
     insufficient_credit: "Not enough credits to enrich.",
-    company_created: "Company Created.",
+    company_created: null,
+    company_updated: null,
     // IAP
     http_error_iap: "Our IAP server is down, please come back later.",
     exhausted_requests:
         "Oops, looks like you have exhausted your free enrichment requests. Please log in to try again.",
-    missing_data: "No data found for this address.",
+    missing_data: "No insights found for this address",
     unknown: "Something bad happened. Please, try again later.",
     // Attachment
     attachments_size_exceeded:

--- a/gmail/src/models/partner.ts
+++ b/gmail/src/models/partner.ts
@@ -204,10 +204,21 @@ export class Partner {
     }
 
     /**
-     * Manually enrich the given partner.
+     * Create and enrich the company of the given partner.
      */
-    static enrichCompany(partnerId: number): [Company, ErrorMessage] {
-        const url = State.odooServerUrl + URLS.ENRICH_COMPANY;
+    static createCompany(partnerId: number): [Company, ErrorMessage] {
+        return this._enrichOrCreateCompany(partnerId, URLS.CREATE_COMPANY);
+    }
+
+    /**
+     * Enrich the existing company.
+     */
+    static enrichCompany(companyId: number): [Company, ErrorMessage] {
+        return this._enrichOrCreateCompany(companyId, URLS.ENRICH_COMPANY);
+    }
+
+    static _enrichOrCreateCompany(partnerId: number, endpoint: string): [Company, ErrorMessage] {
+        const url = State.odooServerUrl + endpoint;
         const accessToken = State.accessToken;
 
         const response = postJsonRpc(url, { partner_id: partnerId }, { Authorization: "Bearer " + accessToken });
@@ -217,7 +228,7 @@ export class Partner {
         }
 
         if (response.error) {
-            return [null, new ErrorMessage("unknown", response.error)];
+            return [null, new ErrorMessage("odoo", response.error)];
         }
 
         let error = new ErrorMessage();

--- a/gmail/src/models/state.ts
+++ b/gmail/src/models/state.ts
@@ -30,6 +30,8 @@ export class State {
     searchedProjects: Project[];
     // Current error message displayed on the card
     error: ErrorMessage;
+    // Used in the company card
+    isCompanyDescriptionUnfolded: boolean;
 
     constructor(
         partner: Partner,
@@ -73,6 +75,9 @@ export class State {
         const searchedProjects = projectsValues
             ? projectsValues.map((projectValues: any) => Project.fromJson(projectValues))
             : null;
+
+        // "isCompanyDescriptionUnfolded" is not copied
+        // to re-fold the description if we go back / refresh
 
         return new State(partner, email, odooUserCompanies, searchedPartners, searchedProjects, error);
     }

--- a/gmail/src/views/company.ts
+++ b/gmail/src/views/company.ts
@@ -1,11 +1,48 @@
 import { buildView } from "./index";
-import { updateCard } from "./helpers";
+import { updateCard, actionCall } from "./helpers";
 import { SOCIAL_MEDIA_ICONS, UI_ICONS } from "./icons";
 import { createKeyValueWidget, actionCall, notify } from "./helpers";
 import { URLS } from "../const";
+import { ErrorMessage } from "../models/error_message";
 import { State } from "../models/state";
 import { Company } from "../models/company";
+import { Partner } from "../models/partner";
 import { _t } from "../services/translation";
+
+/**
+ * Update the application state with the new company created / enriched.
+ * IT could be necessary to also update the contact if the contact is the company itself.
+ */
+function _setContactCompany(state: State, company: Company, error: ErrorMessage) {
+    if (company) {
+        state.partner.company = company;
+        if (state.partner.id === company.id) {
+            // The contact is the same partner as the company
+            // update his information
+            state.partner.isCompany = true;
+            state.partner.image = company.image;
+            state.partner.phone = company.phone;
+            state.partner.mobile = company.mobile;
+        }
+    }
+    state.error = error;
+    return updateCard(buildView(state));
+}
+
+function onCreateCompany(state: State) {
+    const [company, error] = Partner.createCompany(state.partner.id);
+    return _setContactCompany(state, company, error);
+}
+
+function onEnrichCompany(state: State) {
+    const [company, error] = Partner.enrichCompany(state.partner.company.id);
+    return _setContactCompany(state, company, error);
+}
+
+function onUnfoldCompanyDescription(state: State) {
+    state.isCompanyDescriptionUnfolded = true;
+    return updateCard(buildView(state));
+}
 
 export function buildCompanyView(state: State, card: Card) {
     if (state.partner.company) {
@@ -13,30 +50,51 @@ export function buildCompanyView(state: State, card: Card) {
         const cids = state.odooCompaniesParameter;
         const company = state.partner.company;
 
-        const companySection = CardService.newCardSection().setHeader("<b>" + _t("Company") + "</b>");
+        const companySection = CardService.newCardSection().setHeader("<b>" + _t("Company Insights") + "</b>");
 
-        const companyContent = [company.email, company.phone]
-            .filter((x) => x)
-            .map((x) => `<font color="#777777">${x}</font>`);
+        if (!state.partner.id || state.partner.id !== company.id) {
+            const companyContent = [company.email, company.phone]
+                .filter((x) => x)
+                .map((x) => `<font color="#777777">${x}</font>`);
 
-        companySection.addWidget(
-            createKeyValueWidget(
-                null,
-                company.name + "<br>" + companyContent.join("<br>"),
-                company.image || UI_ICONS.no_company,
-                null,
-                null,
-                company.id ? odooServerUrl + `/web#id=${company.id}&model=res.partner&view_type=form${cids}` : null,
-                false,
-                company.email,
-                CardService.ImageCropType.CIRCLE,
-            ),
-        );
+            companySection.addWidget(
+                createKeyValueWidget(
+                    null,
+                    company.name + "<br>" + companyContent.join("<br>"),
+                    company.image || UI_ICONS.no_company,
+                    null,
+                    null,
+                    company.id ? odooServerUrl + `/web#id=${company.id}&model=res.partner&view_type=form${cids}` : null,
+                    false,
+                    company.email,
+                    CardService.ImageCropType.CIRCLE,
+                ),
+            );
+        }
 
         _addSocialButtons(companySection, company);
 
         if (company.description) {
-            companySection.addWidget(createKeyValueWidget(_t("Description"), company.description));
+            const MAX_DESCRIPTION_LENGTH = 70;
+            if (company.description.length < MAX_DESCRIPTION_LENGTH || state.isCompanyDescriptionUnfolded) {
+                companySection.addWidget(createKeyValueWidget(_t("Description"), company.description));
+            } else {
+                companySection.addWidget(
+                    createKeyValueWidget(
+                        _t("Description"),
+                        company.description.substring(0, MAX_DESCRIPTION_LENGTH) +
+                            "..." +
+                            "<br/>" +
+                            "<font color='#1a73e8'>" +
+                            _t("Read more") +
+                            "</font>",
+                        null,
+                        null,
+                        null,
+                        actionCall(state, "onUnfoldCompanyDescription"),
+                    ),
+                );
+            }
         }
 
         if (company.address) {
@@ -93,15 +151,28 @@ export function buildCompanyView(state: State, card: Card) {
         }
 
         card.addSection(companySection);
+
+        if (!company.isEnriched) {
+            const enrichSection = CardService.newCardSection();
+            enrichSection.addWidget(CardService.newTextParagraph().setText(_t("No insights for this company.")));
+            if (state.error.canCreateCompany) {
+                enrichSection.addWidget(
+                    CardService.newTextButton()
+                        .setText(_t("Enrich Company"))
+                        .setOnClickAction(actionCall(state, "onEnrichCompany")),
+                );
+            }
+            card.addSection(enrichSection);
+        }
     } else if (state.partner.id) {
-        const companySection = CardService.newCardSection().setHeader("<b>" + _t("Company") + "</b>");
+        const companySection = CardService.newCardSection().setHeader("<b>" + _t("Company Insights") + "</b>");
         companySection.addWidget(CardService.newTextParagraph().setText(_t("No company attached to this contact.")));
 
         if (state.error.canCreateCompany) {
             companySection.addWidget(
                 CardService.newTextButton()
                     .setText(_t("Create a company"))
-                    .setOnClickAction(actionCall(state, "onEnrichCompany")),
+                    .setOnClickAction(actionCall(state, "onCreateCompany")),
             );
         }
         card.addSection(companySection);

--- a/gmail/src/views/error.ts
+++ b/gmail/src/views/error.ts
@@ -31,6 +31,11 @@ function _addError(message: string, state: State, icon: string = null): CardSect
 export function buildErrorView(state: State, card: Card) {
     const error = state.error;
 
+    const ignoredErrors = ["company_created", "company_updated"];
+    if (ignoredErrors.indexOf(error.code) >= 0) {
+        return;
+    }
+
     if (error.code === "http_error_odoo") {
         const errorSection = _addError(error.message, state);
         errorSection.addWidget(
@@ -47,8 +52,6 @@ export function buildErrorView(state: State, card: Card) {
                 .setOpenLink(CardService.newOpenLink().setUrl(error.information)),
         );
         card.addSection(errorSection);
-    } else if (error.code === "company_created") {
-        card.addSection(_addError(error.message, state, UI_ICONS.check));
     } else if (error.code === "missing_data") {
         card.addSection(_addError(error.message, state));
     } else {

--- a/gmail/src/views/partner.ts
+++ b/gmail/src/views/partner.ts
@@ -13,13 +13,6 @@ import { ErrorMessage } from "../models/error_message";
 import { logEmail } from "../services/log_email";
 import { _t } from "../services/translation";
 
-function onEnrichCompany(state: State) {
-    const [company, error] = Partner.enrichCompany(state.partner.id);
-    state.partner.company = company;
-    state.error = error;
-    return updateCard(buildView(state));
-}
-
 function onLogEmail(state: State) {
     const partnerId = state.partner.id;
 


### PR DESCRIPTION
Purpose
=======
Allow users to enrich and update existing Odoo company from the Gmail
plugin so they can have more information on their contact.

Specifications
==============
When the company exist on the Odoo database but is not enriched, show
a button "Enrich" to enrich the company (and write on the fields).

If the current contact is the company itself, hide the company card to
not have redundant information.

Links
=====
Task-2567566
See odoo/odoo/pull/73762
See /pull/15