### PR TITLE
[FIX] outlook: show a warning message for Internet Explorer users

### DIFF
--- a/outlook/src/taskpane/index.tsx
+++ b/outlook/src/taskpane/index.tsx
@@ -13,6 +13,20 @@ let isOfficeInitialized = false;
 const title = 'Odoo for Outlook';
 
 const render = (Component) => {
+    if (navigator.userAgent.indexOf('Trident') >= 0 || navigator.userAgent.indexOf('Edge') >= 0) {
+        // Use the addin with Internet Explorer
+        ReactDOM.render(
+            <AppContainer>
+                <div className="warning-message">
+                    This addin is unfortunately not compatible with Internet Explorer. Please try again with another
+                    browser.
+                </div>
+            </AppContainer>,
+            document.getElementById('container'),
+        );
+        return;
+    }
+
     ReactDOM.render(
         <AppContainer>
             <Component

--- a/outlook/src/taskpane/taskpane.css
+++ b/outlook/src/taskpane/taskpane.css
@@ -43,6 +43,10 @@
     border-bottom: 1px #d6d5d5 solid;
 }
 
+.warning-message {
+    padding: 20px;
+}
+
 .tile-regular-space {
     height: 30px;
 }


### PR DESCRIPTION
Purpose
=======
The addin use some feature not supported by Internet Explorer.
Show a warning message for those users instead of an infinite load.

Task-2928398