### PR TITLE
[FIX]#45 On GMail, trailing comas are not accepted in the AppsScript.

### DIFF
--- a/gmail/.prettierrc
+++ b/gmail/.prettierrc
@@ -1,6 +1,6 @@
 {
   "semi": true,
-  "trailingComma": "all",
+  "trailingComma": "none",
   "singleQuote": false,
   "printWidth": 120,
   "tabWidth": 4


### PR DESCRIPTION
Following the given install flow is then buggy.
Fix by removing trailing comas in the .prettierrc.