### PR TITLE
[IMP] Support Shared Mailboxes in Outlook

### DIFF
--- a/outlook/manifest.xml
+++ b/outlook/manifest.xml
@@ -98,6 +98,7 @@
       <Hosts>
         <Host xsi:type="MailHost">
           <DesktopFormFactor>
+            <SupportsSharedFolders>true</SupportsSharedFolders>
             <FunctionFile resid="Commands.Url"/>
             <ExtensionPoint xsi:type="MessageReadCommandSurface">
               <OfficeTab id="TabDefault">


### PR DESCRIPTION
Previously, when trying to use it with a "Shared Mailbox", it would simply not show up(Outlook) or show an error about it being unsupported(Classic Outlook).

This simple change allows it to work in such context and it has been tested on Outlook and Outlook Classic.