### PR TITLE
[IMP] gmail: make init_db idempotent

### DIFF
--- a/gmail/README.md
+++ b/gmail/README.md
@@ -4,7 +4,8 @@ and also to link your Gmail contacts to your Odoo partners, to create leads from
 
 # Development
 Create the database and fill the credentials in `consts.ts`
-> psql -U root -d postgres -f init_db.sql
+> createdb odoo_gmail_addin
+> psql -f init_db.sql odoo_gmail_addin
 
 To serve the addin, you need a public HTTPS connection to your application.
 You cannot use nrgok, because Gmail store all images we use in the addin,

--- a/gmail/init_db.sql
+++ b/gmail/init_db.sql
@@ -1,8 +1,14 @@
-CREATE DATABASE odoo_gmail_addin_db;
+-- For production:
+-- CREATE DATABASE must be run as root (e.g. postgres).
+-- This script must be run as a dedicated user (e.g. gmail_addin) which has
+-- the rights to create and alter tables.
+-- For development:
+-- CREATE DATABASE as well as this script can be run as any superuser.
+-- Example:
+-- createdb odoo_gmail_addin
+-- psql -f init_db.sql odoo_gmail_addin
 
-\c odoo_gmail_addin_db;
-
-CREATE TABLE users_settings (
+CREATE TABLE IF NOT EXISTS users_settings (
     id SERIAL PRIMARY KEY,
     email TEXT UNIQUE NOT NULL,
     odoo_url TEXT,
@@ -13,8 +19,7 @@ CREATE TABLE users_settings (
     translations_expire_at TIMESTAMP WITH TIME ZONE
 );
 
--- Remember that the user logged the email on the giver record
-CREATE TABLE email_logs (
+CREATE TABLE IF NOT EXISTS email_logs (
     id SERIAL PRIMARY KEY,
     user_id INTEGER NOT NULL,
     message_id TEXT NOT NULL,

--- a/gmail/src/consts.ts
+++ b/gmail/src/consts.ts
@@ -6,7 +6,7 @@ export const CLIENT_ID =
 // PSQL config
 export const PSQL_USER = process.env.PSQL_USER || "root";
 export const PSQL_PASS = process.env.PSQL_PASS || "root";
-export const PSQL_DB = process.env.PSQL_DB || "odoo_gmail_addin_db";
+export const PSQL_DB = process.env.PSQL_DB || "odoo_gmail_addin";
 export const PSQL_HOST = process.env.PSQL_HOST || "localhost";
 export const PSQL_PORT = Number(process.env.PSQL_PORT || 5432);
 


### PR DESCRIPTION
We make sure the `init_db.sql` can be run multiple times without failing. Moreover, we remove the `CREATE DATABASE` part: this should generally be executed outside of the script.