### PR TITLE
[IMP] gmail: make SSL for PostgreSQL connection configurable

### DIFF
--- a/gmail/src/consts.ts
+++ b/gmail/src/consts.ts
@@ -9,6 +9,7 @@ export const PSQL_PASS = process.env.PSQL_PASS || "root";
 export const PSQL_DB = process.env.PSQL_DB || "odoo_gmail_addin";
 export const PSQL_HOST = process.env.PSQL_HOST || "localhost";
 export const PSQL_PORT = Number(process.env.PSQL_PORT || 5432);
+export const PSQL_SSL = process.env.PSQL_SSL === "true";
 
 export const URLS: Record<string, string> = {
     GET_TRANSLATIONS: "/mail_plugin/get_translations",

--- a/gmail/src/utils/db.ts
+++ b/gmail/src/utils/db.ts
@@ -1,5 +1,5 @@
 import { Pool } from "pg";
-import { PSQL_DB, PSQL_HOST, PSQL_PASS, PSQL_PORT, PSQL_USER } from "../consts";
+import { PSQL_DB, PSQL_HOST, PSQL_PASS, PSQL_PORT, PSQL_SSL, PSQL_USER } from "../consts";
 
 const pool = new Pool({
     user: PSQL_USER,
@@ -7,6 +7,7 @@ const pool = new Pool({
     database: PSQL_DB,
     host: PSQL_HOST,
     port: PSQL_PORT,
+    ssl: PSQL_SSL ? { rejectUnauthorized: false } : false,
 });
 
 pool.on("error", (err, client) => {


### PR DESCRIPTION
Add PSQL_SSL environment variable to control whether the node-postgres client connects over SSL. Required when pg_hba.conf enforces hostssl connections. Uses
rejectUnauthorized: false to support servers with
self-signed certificates. Defaults to false for backward compatibility.